### PR TITLE
Calling ExtensionManagementUtility::extRelPath() will trigger a depre…

### DIFF
--- a/Configuration/TCA/Sitemap.php
+++ b/Configuration/TCA/Sitemap.php
@@ -45,7 +45,7 @@ $GLOBALS['TCA']['tx_twsitemap_domain_model_sitemap'] = array(
             'endtime' => 'endtime',
         ),
         'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('tw_sitemap').'Configuration/TCA/Sitemap.php',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('tw_sitemap').'Resources/Public/Icons/tx_twsitemap_domain_model_sitemap.gif'
+        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('tw_sitemap').'Resources/Public/Icons/tx_twsitemap_domain_model_sitemap.gif'
     ),
     'interface' => array(
         'showRecordFieldList' => 'domain, target_domain, scheme, gz',


### PR DESCRIPTION
…cation log entry. [TYPO3 7.6]

Use alternatives for resolving paths. There are the following methods available: * ExtensionManagementUtility::extPath() - to resolve the full path of an extension * ExtensionManagementUtility::siteRelPath() - to resolve the location of an extension relative to PATH_site * GeneralUtility::getFileAbsFileName() - to resolve a file/path prefixed with EXT:myext * PathUtility::getAbsoluteWebPath() - used for output a file location (previously resolved with GeneralUtility::getFileAbsFileName()) that is absolutely prefixed for the web folder